### PR TITLE
Enable RSS feed plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: jekyll-theme-cayman
+plugins:
+  - jekyll-feed


### PR DESCRIPTION
Untested but based on: https://help.github.com/articles/atom-rss-feeds-for-github-pages/